### PR TITLE
Prevent error "(max - min)" must be divisible by "interval"

### DIFF
--- a/components/CustomPriceSlider.vue
+++ b/components/CustomPriceSlider.vue
@@ -3,8 +3,8 @@
     <h2>Price Selector</h2>
       <vue-slider
         v-model="dynamicPrice.values"
-        :min="Math.min(minAvailablePrice, dynamicPrice.values[0])"
-        :max="Math.max(maxAvailablePrice, dynamicPrice.values[1])"
+        :min="Math.round(Math.min(minAvailablePrice, dynamicPrice.values[0]))"
+        :max="Math.round(Math.max(maxAvailablePrice, dynamicPrice.values[1]))"
         lazy
       />
   </div>


### PR DESCRIPTION
When the min or max value is called with a number that has a decimal it gives this error: "(max - min)" must be divisible by "interval"
This is because the interval setting is set to 1 by default: https://nightcatsama.github.io/vue-slider-component/#interval So I think it's a good idea to always use whole numbers for this.